### PR TITLE
bc-2375 Исправление кнопки сравнения

### DIFF
--- a/src/files/templates/demomarket/php/catalog/product/main/price/actions/compare.phtml
+++ b/src/files/templates/demomarket/php/catalog/product/main/price/actions/compare.phtml
@@ -7,11 +7,12 @@
  */
 
 $product = $variables;
+$data = $this->macros('emarket', 'getCompareLink', [$product->getId()]);
 ?>
 
 <div class="col-md-6 col-lg-3 rew diff">
-	<a href="<?= $this->getProductComparisonLink($product) ?>">
+	<a href="<?= $this->getProductComparisonLink($data) ?>">
 		<i class="sprite-item sprite-item_icons_circle_blue inline"></i>
-		<?= $this->getComparisonMessage($product) ?>
+		<?= $this->getComparisonMessage($data) ?>
 	</a>
 </div>


### PR DESCRIPTION
https://youtrack.umisoft.ru/issue/bc-2375

Кнопка "Удалить из сравнения" всегда активна для карточки товара (не превью) и ведёт на 404 страницу. 
